### PR TITLE
Fix compiler command and amend Makefile accordingly.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ test clean:
 	make -C rubbermallet $@
 	make -C gianlucag $@
 
-generate_test_case: solid65.h opcodes.h
+generate_test_case:


### PR DESCRIPTION
Fixes #1.

After this change I get

```
> make
cc     generate_test_case.c   -o generate_test_case
```

which generates the correct `generate_test_case` binary.